### PR TITLE
add missing dependency

### DIFF
--- a/batch/requirements.txt
+++ b/batch/requirements.txt
@@ -1,2 +1,3 @@
 dapr
 Flask
+typing_extensions


### PR DESCRIPTION
Got a module not found error for `typing_extensions`. 