### PR TITLE
Change PostgreSQL version from 13 to 17

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -107,7 +107,7 @@ module postgresServer './core/database/postgres/sql/postgres-sql-db.bicep' = {
     storage: {
       storageSizeGB: 32
     }
-    version: '13'
+    version: '17'
     allowAllIPsFirewall: true
     administratorLogin: postgresUser
     administratorLoginPassword: pgPassword


### PR DESCRIPTION
This PR changes the PostgreSQL version from 13 to 17.

When you follow the steps in this repo's [read-me file](https://github.com/Azure-Samples/bindings-dapr-python-cron-postgres/blob/main/README.md), you deploy an Azure Database for PostgreSQL flexible server. On the **Overview** page of that resource, the Azure portal displays the following warning message: "Your server is currently running PostgreSQL version 13 which will reach end-of-life (EOL) on November 13, 2025."

To eliminate that warning, this PR updates the PostgreSQL version of that resource. Version 13, which is specified in the [main.bicep](https://github.com/Azure-Samples/bindings-dapr-python-cron-postgres/blob/main/infra/main.bicep) file, is [no longer supported](https://endoflife.date/postgresql). This PR changes the PostgreSQL version to 17, which has [support through November 8, 2029](https://endoflife.date/postgresql).